### PR TITLE
Add Thunderstorm, Force Reload & Loose Trigger

### DIFF
--- a/addons/sourcemod/configs/Chaos/Chaos_Effects.cfg
+++ b/addons/sourcemod/configs/Chaos/Chaos_Effects.cfg
@@ -707,4 +707,11 @@
 		"enabled"		"1"
 		"duration"		"-1"
 	}
+	"Chaos_Thunderstorm"
+	{
+		"name"			"Thunderstorm"
+		"description"		"Spawns rain and strikes lightning around the map"
+		"enabled"		"1"
+		"duration"		"-1"
+	}
 }

--- a/addons/sourcemod/configs/Chaos/Chaos_Effects.cfg
+++ b/addons/sourcemod/configs/Chaos/Chaos_Effects.cfg
@@ -712,6 +712,20 @@
 		"name"			"Thunderstorm"
 		"description"		"Spawns rain and strikes lightning around the map"
 		"enabled"		"1"
+		"duration"		"20"
+	}
+	"Chaos_ForceReload"
+	{
+		"name"			"ForceReload"
+		"description"		"Forces all alive players to reload"
+		"enabled"		"1"
 		"duration"		"-1"
+	}
+		"Chaos_LooseTrigger"
+	{
+		"name"			"Loose Trigger"
+		"description"		"Forces all players to shoot"
+		"enabled"		"1"
+		"duration"		"5"
 	}
 }

--- a/addons/sourcemod/scripting/Chaos.sp
+++ b/addons/sourcemod/scripting/Chaos.sp
@@ -30,6 +30,7 @@ char 	g_Prefix[] = ">>{lime}C H A O S{default}<<";
 char 	g_Prefix_EndChaos[] = "<<{darkred}Ended{default}>>";
 char 	g_Prefix_MegaChaos[] = "\n<<{orange}C H A O S{default}>>";
 
+
 StringMap	Chaos_Effects;
 
 #define SOUND_BELL "buttons/bell1.wav"
@@ -93,6 +94,7 @@ int g_MaxAirAcc = 0;
 #include "Externals/Rollback.sp"
 #include "Externals/Fog.sp"
 #include "Externals/Impostors.sp"
+#include "Externals/Weather.sp"
 
 #include "Effects.sp"
 
@@ -158,6 +160,7 @@ public void OnMapStart(){
 	PrecacheSound(SOUND_MONEY);
 	PrecacheSound(SOUND_BLIP);
 
+
 	PrecacheTextures();
 
 	if(g_MapCoordinates != 	INVALID_HANDLE) ClearArray(g_MapCoordinates);
@@ -180,6 +183,7 @@ public void OnMapStart(){
 	EXPLOSIVEBULLETS_INIT();
 	DRUGS_INIT();
 	TELEPORT_INIT();
+	WEATHER_INIT();
 	
 	Overlay_INIT();
 

--- a/addons/sourcemod/scripting/Effects.sp
+++ b/addons/sourcemod/scripting/Effects.sp
@@ -2443,7 +2443,7 @@ public Action Timer_CompleteMegaChaos(Handle timer){
 	g_bMegaChaos = false;
 }
 
-Handle g_Thunder_Timer = INVALID_HANDLE; //made by ozai, holla if issue and cbf fixing
+Handle g_Thunder_Timer = INVALID_HANDLE; 
 
 Action Chaos_Thunderstorm(Handle timer = null, bool EndChaos = false){
 	if(ClearChaos(EndChaos)){
@@ -2459,7 +2459,7 @@ Action Chaos_Thunderstorm(Handle timer = null, bool EndChaos = false){
 			}
 		}
 	}
-	if(NotDecidingChaos("Chaos_Thunderstorm")) return;
+	if(NotDecidingChaos("Chaos_Thunderstorm.Lightning")) return;
 	if(CurrentlyActive(g_Thunder_Timer)) return;
 
 	CreateTimer(0.1, Timer_LightningStrike); // starting lightning strikes
@@ -2517,4 +2517,41 @@ public Action Timer_LightningStrike(Handle timer) {
 			}
 		}
 	}
+}
+
+bool g_bForce_Reload[MAXPLAYERS+1];
+
+public void Chaos_ForceReload(){
+	if(ClearChaos()){
+		for(int i = 0; i <= MaxClients; i++) g_bForce_Reload[i] = false;
+	}
+	if(NotDecidingChaos("Chaos_ForceReload")) return;
+	
+	for(int i = 0; i <= MaxClients; i++) if(ValidAndAlive(i)) g_bForce_Reload[i] = true;
+
+	AnnounceChaos(GetChaosTitle("Chaos_ForceReload"), -1.0);
+
+}
+
+bool g_bLoose_Trigger = false;
+bool g_bLast_Shot [MAXPLAYERS+1];
+
+Handle g_LooseTrigger_Timer = INVALID_HANDLE;
+
+Action Chaos_LooseTrigger(Handle timer = null, bool EndChaos = false){
+	if(ClearChaos(EndChaos)){
+		StopTimer(g_LooseTrigger_Timer);
+		g_bLoose_Trigger = false;
+	}
+	if(NotDecidingChaos("Chaos_LooseTrigger.forceshoot")) return;
+	if(CurrentlyActive(g_LooseTrigger_Timer)) return;
+
+	for(int i = 0; i <= MaxClients; i++)  g_bLast_Shot[i] = true;
+	g_bLoose_Trigger = true;
+
+	float duration = GetChaosTime("Chaos_LooseTrigger", 5.0);
+	if(duration > 0) g_LooseTrigger_Timer = CreateTimer(duration, Chaos_LooseTrigger, true);
+
+	AnnounceChaos(GetChaosTitle("Chaos_LooseTrigger"), duration);
+	
 }

--- a/addons/sourcemod/scripting/EffectsHandler.sp
+++ b/addons/sourcemod/scripting/EffectsHandler.sp
@@ -107,6 +107,7 @@ void Chaos(bool reset = false){
 		if(ValidMapPoints()){
 			if(IsChaosEnabled("Chaos_RespawnTheDead_Randomly"))  Chaos_RespawnTheDead_Randomly();
 		}
+		if(IsChaosEnabled("Chaos_ForceReload"))  Chaos_ForceReload(); // Ozai
 	}
 	if(ValidMapPoints()){
 		if(g_bCanSpawnChickens || reset){
@@ -126,6 +127,8 @@ void Chaos(bool reset = false){
 		if(IsChaosEnabled("Chaos_SpawnExplodingBarrels"))  Chaos_SpawnExplodingBarrels();
 	}
 	if(IsChaosEnabled("Chaos_Thunderstorm"))  Chaos_Thunderstorm(); // Ozai
+	if(IsChaosEnabled("Chaos_LooseTrigger"))  Chaos_LooseTrigger(); // Ozai
+
 	g_bClearChaos = false;
 }
 
@@ -171,5 +174,6 @@ char EffectsWithNoDuration[][] = {
 	"Chaos_TeleportFewMeters",
 	"Chaos_SpawnFlashbangs",
 	"Chaos_SpawnExplodingBarrels",
-	"Chaos_SimonSays"
+	"Chaos_SimonSays",
+	"Chaos_ForceReload"
 };

--- a/addons/sourcemod/scripting/EffectsHandler.sp
+++ b/addons/sourcemod/scripting/EffectsHandler.sp
@@ -2,6 +2,7 @@
 void Chaos(bool reset = false){
 	if(g_bFindingPotentialEffects) reset = true;
 	if(IsChaosEnabled("Chaos_Nothing"))  Chaos_Nothing(); //cannot be turned off
+	
 	if(IsChaosEnabled("Chaos_NoScopeOnly"))  Chaos_NoScopeOnly();
 	if(IsChaosEnabled("Chaos_PortalGuns"))  Chaos_PortalGuns();
 	if(IsChaosEnabled("Chaos_Aimbot"))  Chaos_Aimbot();
@@ -124,6 +125,7 @@ void Chaos(bool reset = false){
 		if(IsChaosEnabled("Chaos_SpawnFlashbangs"))  Chaos_SpawnFlashbangs();
 		if(IsChaosEnabled("Chaos_SpawnExplodingBarrels"))  Chaos_SpawnExplodingBarrels();
 	}
+	if(IsChaosEnabled("Chaos_Thunderstorm"))  Chaos_Thunderstorm(); // Ozai
 	g_bClearChaos = false;
 }
 

--- a/addons/sourcemod/scripting/Events.sp
+++ b/addons/sourcemod/scripting/Events.sp
@@ -145,6 +145,23 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &iImpulse, float fVel
 		g_DisableKeys_OriginalPos[client][2] = 0.0;
 	}
 
+	if (g_bForce_Reload[client]) {
+		buttons |= IN_RELOAD;
+		g_bForce_Reload[client] = false;
+		//return Plugin_Changed;
+	}
+
+	if (g_bLoose_Trigger) {
+		if (g_bLast_Shot[client]) {
+			buttons |= IN_ATTACK;
+			g_bLast_Shot[client] = false;
+		} else {
+			buttons &= ~IN_ATTACK;
+			g_bLast_Shot[client] = true;
+		}
+		//return Plugin_Changed;
+	}
+
 	return Plugin_Continue;
 }
 

--- a/addons/sourcemod/scripting/Externals/ExplosiveBullets.sp
+++ b/addons/sourcemod/scripting/Externals/ExplosiveBullets.sp
@@ -5,7 +5,7 @@ bool g_bExplosiveBullets = false;
 #define FLASH "explosion_child_core04b"
 #define SMOKE "impact_dirt_child_smoke_puff"
 #define DIRT "impact_dirt_child_clumps"
-#define SOUND "weapons/hegrenade/explode5.wav"
+#define EXPLOSION_HE "weapons/hegrenade/explode5.wav"
 
 public void EXPLOSIVEBULLETS_INIT(){
 	PrecacheEffect("ParticleEffect");
@@ -13,7 +13,7 @@ public void EXPLOSIVEBULLETS_INIT(){
 	PrecacheParticleEffect(FLASH);
 	PrecacheParticleEffect(SMOKE);
 	PrecacheParticleEffect(DIRT);
-	PrecacheSound(SOUND);
+	PrecacheSound(EXPLOSION_HE);
 }
 public Action Explosive_Event_BulletImpact(Event event, const char[] name, bool dontBroadcast){
 	if (!g_bExplosiveBullets) return Plugin_Continue;
@@ -50,7 +50,7 @@ public Action Explosive_Hook_BulletShot(const char[] te_name, const int[] Player
 	}
 	delete trace;
 	//Play the explosion sound
-	EmitAmbientSound(SOUND, endpos, SOUND_FROM_WORLD, SNDLEVEL_NORMAL, SND_NOFLAGS, 0.5, SNDPITCH_HIGH);
+	EmitAmbientSound(EXPLOSION_HE, endpos, SOUND_FROM_WORLD, SNDLEVEL_NORMAL, SND_NOFLAGS, 0.5, SNDPITCH_HIGH);
 	return Plugin_Continue;
 }
 

--- a/addons/sourcemod/scripting/Externals/Weather.sp
+++ b/addons/sourcemod/scripting/Externals/Weather.sp
@@ -1,0 +1,52 @@
+char PrecipitationModel[128];
+
+#define SOUND_SUPERSLAY  "weapons/hegrenade/hegrenade_detonate_02.wav"
+#define LIGHTNING_EFFECT "sprites/lgtning.vmt"
+#define TYPE_SNOWFALL define value
+enum WEATHER_TYPE{
+    RAIN,
+    SNOW,
+    ASH,
+    SNOWFALL,
+    PARTICLE_RAIN,
+    PARTICLE_RAINSTORM,
+    PARTICLE_SNOW,
+};
+int    LIGHTNING_sprite = -1;
+
+float map_vecOrigin[3];
+float map_maxbounds[3];
+float map_minbounds[3];
+
+void WEATHER_INIT(){
+    PrecacheSound(SOUND_SUPERSLAY);
+
+    LIGHTNING_sprite = PrecacheModel(LIGHTNING_EFFECT);
+
+    Format(PrecipitationModel, sizeof(PrecipitationModel), "maps/%s.bsp", mapName);
+    PrecacheModel(PrecipitationModel, true);
+    GetEntPropVector(0, Prop_Data, "m_WorldMins", map_minbounds); // rain shit
+    GetEntPropVector(0, Prop_Data, "m_WorldMaxs", map_maxbounds);
+
+    map_vecOrigin[0] = (map_minbounds[0] + map_maxbounds[0]) / 2;
+    map_vecOrigin[1] = (map_minbounds[1] + map_maxbounds[1]) / 2;
+    map_vecOrigin[2] = (map_minbounds[2] + map_maxbounds[2]) / 2;
+
+}
+
+void SPAWN_WEATHER(WEATHER_TYPE type){
+    int ent = CreateEntityByName("func_precipitation");
+    char PrecipType[8];
+    FormatEx(PrecipType, sizeof(PrecipType), "%i.0", view_as<int>(type));
+    DispatchKeyValue(ent, "model", PrecipitationModel);
+    DispatchKeyValue(ent, "preciptype", PrecipType);
+    DispatchKeyValue(ent, "renderamt", "5.0");
+    DispatchKeyValue(ent, "density", "100");
+    DispatchKeyValue(ent, "rendercolor", "255 255 255");
+    DispatchSpawn(ent);
+    ActivateEntity(ent);
+
+    SetEntPropVector(ent, Prop_Send, "m_vecMins", map_minbounds);
+    SetEntPropVector(ent, Prop_Send, "m_vecMaxs", map_maxbounds);    
+    TeleportEntity(ent, map_vecOrigin, NULL_VECTOR, NULL_VECTOR); 
+}

--- a/addons/sourcemod/translations/chaos.phrases.txt
+++ b/addons/sourcemod/translations/chaos.phrases.txt
@@ -824,4 +824,20 @@
     {
         "en"    "Spawns rain and strikes lightning around the map"
     }
+    "Chaos_ForceReload_Title"
+    {
+        "en"    "Force Reload"
+    }
+    "Chaos_ForceReload_Description"
+    {
+        "en"    "Forces all players to reload their weapon"
+    }
+    "Chaos_LooseTrigger_Title"
+    {
+        "en"    "Loose Trigger"
+    }
+    "Chaos_LooseTrigger_Description"
+    {
+        "en"    "Forces all players to shoot"
+    }
 }

--- a/addons/sourcemod/translations/chaos.phrases.txt
+++ b/addons/sourcemod/translations/chaos.phrases.txt
@@ -1,820 +1,827 @@
 "Phrases"
 {
-	"Chaos_MEGACHAOS_Title"
-	{
-		"en"		"MEGA CHAOS"
-	}
-	"Chaos_MEGACHAOS_Description"
-	{
-		"en"		"Runs 5 Chaos Effects at the same time"
-	}
-	"Chaos_Nothing_Title"
-	{
-		"en"		"Nothing"
-	}
-	"Chaos_Nothing_Description"
-	{
-		"en"		"Nothing..."    
-	}
-	"Chaos_Invis_Title"
-	{
-		"en"		"Where did everyone go?"
-	}
-	"Chaos_Invis_Description"
-	{
-		"en"		"All players are almost invisible, (barely visible if duration = 0, otherwise full invis if effect expires)"
-	}
-	"Chaos_OneBulletMag_Title"
-	{
-		"en"		"One Bullet Mags"
-	}
-	"Chaos_OneBulletMag_Description"
-	{
-		"en"		"You can only shoot once before having to reload"
-	}
-	"Chaos_PortalGuns_Title"
-	{
-		"en"		"Portal Guns"
-	}
-	"Chaos_PortalGuns_Description"
-	{
-		"en"		"Teleport where you shoot"
-	}
-	"Chaos_NoScopeOnly_Title"
-	{
-		"en"		"No Scopes Only"
-	}
-	"Chaos_NoScopeOnly_Description"
-	{
-		"en"		"Prevent players from using their scopes, if the weapon has one"
-	}
-	"Chaos_Aimbot_Title"
-	{
-		"en"		"Aimbot"
-	}
-	"Chaos_Aimbot_Description"
-	{
-		"en"		"Toggles on a sourcemod based Aimbot for all players"
-	}
-	"Chaos_InfiniteAmmo_Title"
-	{
-		"en"		"Infinite Ammo"
-	}
-	"Chaos_InfiniteAmmo_Description"
-	{
-		"en"		"Never run out of ammo"
-	}
-	"Chaos_RandomSkybox_Title"
-	{
-		"en"		"Random Skybox"
-	}
-	"Chaos_RandomSkybox_Description"
-	{
-		"en"		"Changes the skybox from a random selection of 20 default CSGO skyboxes (works on maps that dont have a 3d skybox)"
-	}
-	"Chaos_DecoyDodgeball_Title"
-	{
-		"en"		"Decoy Dodgeball"
-	}
-	"Chaos_DecoyDodgeball_Description"
-	{
-		"en"		"Sets everyones HP to 1 and gives everyones decoys, players are restricted from using other weapons"
-	}
-	"Chaos_RandomInvisiblePlayer_Title"
-	{
-		"en"		"Random Invisible Player"
-	}
-	"Chaos_RandomInvisiblePlayer_Description"
-	{
-		"en"		"Makes one player in the server invisible (only works if there are 2+ players)"
-	}
-	"Chaos_Bankrupt_Title"
-	{
-		"en"		"Bankrupt"
-	}
-	"Chaos_Bankrupt_Description"
-	{
-		"en"		"Sets every player's cash to $0"
-	}
-	"Chaos_Shields_Title"
-	{
-		"en"		"Shields"
-	}
-	"Chaos_Shields_Description"
-	{
-		"en"		"Gives all players weapon_shield"
-	}
-	"Chaos_BlindPlayers_Title"
-	{
-		"en"		"Blind"
-	}
-	"Chaos_BlindPlayers_Description"
-	{
-		"en"		"Blinds all players"
-	}
-	"Chaos_AutoPlantC4_Title"
-	{
-		"en"		"Auto Plant C4"
-	}
+    "Chaos_MEGACHAOS_Title"
+    {
+        "en"    "MEGA CHAOS"
+    }
+    "Chaos_MEGACHAOS_Description"
+    {
+        "en"    "Runs 5 Chaos Effects at the same time"
+    }
+    "Chaos_Nothing_Title"
+    {
+        "en"    "Nothing"
+    }
+    "Chaos_Nothing_Description"
+    {
+        "en"    "Nothing..."
+    }
+    "Chaos_Invis_Title"
+    {
+        "en"    "Where did everyone go?"
+    }
+    "Chaos_Invis_Description"
+    {
+        "en"    "All players are almost invisible, (barely visible if duration = 0, otherwise full invis if effect expires)"
+    }
+    "Chaos_OneBulletMag_Title"
+    {
+        "en"    "One Bullet Mags"
+    }
+    "Chaos_OneBulletMag_Description"
+    {
+        "en"    "You can only shoot once before having to reload"
+    }
+    "Chaos_PortalGuns_Title"
+    {
+        "en"    "Portal Guns"
+    }
+    "Chaos_PortalGuns_Description"
+    {
+        "en"    "Teleport where you shoot"
+    }
+    "Chaos_NoScopeOnly_Title"
+    {
+        "en"    "No Scopes Only"
+    }
+    "Chaos_NoScopeOnly_Description"
+    {
+        "en"    "Prevent players from using their scopes, if the weapon has one"
+    }
+    "Chaos_Aimbot_Title"
+    {
+        "en"    "Aimbot"
+    }
+    "Chaos_Aimbot_Description"
+    {
+        "en"    "Toggles on a sourcemod based Aimbot for all players"
+    }
+    "Chaos_InfiniteAmmo_Title"
+    {
+        "en"    "Infinite Ammo"
+    }
+    "Chaos_InfiniteAmmo_Description"
+    {
+        "en"    "Never run out of ammo"
+    }
+    "Chaos_RandomSkybox_Title"
+    {
+        "en"    "Random Skybox"
+    }
+    "Chaos_RandomSkybox_Description"
+    {
+        "en"    "Changes the skybox from a random selection of 20 default CSGO skyboxes (works on maps that dont have a 3d skybox)"
+    }
+    "Chaos_DecoyDodgeball_Title"
+    {
+        "en"    "Decoy Dodgeball"
+    }
+    "Chaos_DecoyDodgeball_Description"
+    {
+        "en"    "Sets everyones HP to 1 and gives everyones decoys, players are restricted from using other weapons"
+    }
+    "Chaos_RandomInvisiblePlayer_Title"
+    {
+        "en"    "Random Invisible Player"
+    }
+    "Chaos_RandomInvisiblePlayer_Description"
+    {
+        "en"    "Makes one player in the server invisible (only works if there are 2+ players)"
+    }
+    "Chaos_Bankrupt_Title"
+    {
+        "en"    "Bankrupt"
+    }
+    "Chaos_Bankrupt_Description"
+    {
+        "en"    "Sets every player's cash to $0"
+    }
+    "Chaos_Shields_Title"
+    {
+        "en"    "Shields"
+    }
+    "Chaos_Shields_Description"
+    {
+        "en"    "Gives all players weapon_shield"
+    }
+    "Chaos_BlindPlayers_Title"
+    {
+        "en"    "Blind"
+    }
+    "Chaos_BlindPlayers_Description"
+    {
+        "en"    "Blinds all players"
+    }
+    "Chaos_AutoPlantC4_Title"
+    {
+        "en"    "Auto Plant C4"
+    }
     "Chaos_AutoPlantC4_A_Title"
-	{
-		"en"		"Auto Plant C4 at Bombsite A"
-	}
+    {
+        "en"    "Auto Plant C4 at Bombsite A"
+    }
     "Chaos_AutoPlantC4_B_Title"
-	{
-		"en"		"Auto Plant C4 at Bombsite B"
-	}
-	"Chaos_AutoPlantC4_Description"
-	{
-		"en"		"Auto plants the c4 bomb at the closest bombsite to the player holding the c4, if c4 is dropped, bombsite is random"
-	}
-	"Chaos_InfiniteGrenades_Title"
-	{
-		"en"		"Infinite Grenades"
-	}
-	"Chaos_InfiniteGrenades_Description"
-	{
-		"en"		"Give players grenades and set sv_infinite_ammo to 2 (nades only)"
-	}
-	"Chaos_KnifeFight_Title"
-	{
-		"en"		"Knife Fight"
-	}
-	"Chaos_KnifeFight_Description"
-	{
-		"en"		"Restricts everyones weapons to knife only"
-	}
-	"Chaos_LowRenderDistance_Title"
-	{
-		"en"		"Low Render Distance"
-	}
-	"Chaos_LowRenderDistance_Description"
-	{
-		"en"		"Set fog farz to a lower value that prevents anything further than set distance to render"
-	}
-	"Chaos_RandomWeapons_Title"
-	{
-		"en"		"Random Weapons"
-	}
-	"Chaos_RandomWeapons_Description"
-	{
-		"en"		"Give players random weapons every x seconds (interval setting). An interval of 0 will only spawn the random weapons once"
-	}
-	"Chaos_OHKO_Title"
-	{
-		"en"		"1 HP"
-	}
-	"Chaos_OHKO_Description"
-	{
-		"en"		"Sets everyones HP to 1 (One Hit Knockout)"
-	}
-	"Chaos_TeammateSwap_Title"
-	{
-		"en"		"Teammate Swap"
-	}
-	"Chaos_TeammateSwap_Description"
-	{
-		"en"		"Swap positions with all your teammates"
-	}
-	"Chaos_Flying_Title"
-	{
-		"en"		"Flying"
-	}
-	"Chaos_Flying_Description"
-	{
-		"en"		"Sets all players to noclip, but players can still be damaged"
-	}
-	"Chaos_MoneyRain_Title"
-	{
-		"en"		"Make it rain"
-	}
-	"Chaos_MoneyRain_Description"
-	{
-		"en"		"Spawns item_cash around the map that gives players $500 money"
-	}
-	"Chaos_Thirdperson_Title"
-	{
-		"en"		"Thirdperson"
-	}
-	"Chaos_Thirdperson_Description"
-	{
-		"en"		"Sets all players POV to thirdperson"
-	}
-	"Chaos_C4Chicken_Title"
-	{
-		"en"		"C4 Chicken"
-	}
-	"Chaos_C4Chicken_Description"
-	{
-		"en"		"Sets any current c4, or future planted c4 to morph into a chicken that run around the map"
-	}
-	"Chaos_AlienModelKnife_Title"
-	{
-		"en"		"Alien Knife Fight"
-	}
-	"Chaos_AlienModelKnife_Description"
-	{
-		"en"		"Sets players movement speed to 3x, restricts weapons to knife, and morphs all player models to look oddly skinny"
-	}
-	"Chaos_IsThisMexico_Title"
-	{
-		"en"		"Is This What Mexico Looks Like?"
-	}
-	"Chaos_IsThisMexico_Description"
-	{
-		"en"		"Give a thick orange hue to the map"
-	}
-	"Chaos_HeadshotOnly_Title"
-	{
-		"en"		"Headshots Only"
-	}
-	"Chaos_HeadshotOnly_Description"
-	{
-		"en"		"Sets mp_damage_headshot_only to 1, forcing players to shoot at the head only"
-	}
-	"Chaos_RandomMolotovSpawn_Title"
-	{
-		"en"		"Raining Fire"
-	}
-	"Chaos_RandomMolotovSpawn_Description"
-	{
-		"en"		"Spawns a molotov above every players head. The duration controls how many times it repeats"
-	}
-	"Chaos_RandomTeleport_Title"
-	{
-		"en"		"Random Teleport"
-	}
-	"Chaos_RandomTeleport_Description"
-	{
-		"en"		"Teleports all players to a random location"
-	}
-	"Chaos_LavaFloor_Title"
-	{
-		"en"		"THE FLOOR IS LAVA"
-	}
-	"Chaos_LavaFloor_Description"
-	{
-		"en"		"Spawns molotovs all around the map"
-	}
-	"Chaos_CrabPeople_Title"
-	{
-		"en"		"Crab People"
-	}
-	"Chaos_CrabPeople_Description"
-	{
-		"en"		"Restricts players movement to crouch walking only"
-	}
-	"Chaos_Spin180_Title"
-	{
-		"en"		"180 Spin"
-	}
-	"Chaos_Spin180_Description"
-	{
-		"en"		"Spin players cameras the opposite direction from where theyre looking"
-	}
-	"Chaos_OneWeaponOnly_Title"
-	{
-		"en"		"One weapon Only"
-	}
-	"Chaos_OneWeaponOnly_Description"
-	{
-		"en"		"Give all players the same random gun and disable weapon dropping"
-	}
-	"Chaos_NoSpread_Title"
-	{
-		"en"		"100% Weapon Accuracy"
-	}
-	"Chaos_NoSpread_Description"
-	{
-		"en"		"Set guns to have no recoil"
-	}
-	"Chaos_LittleChooks_Title"
-	{
-		"en"		"Little Chooks"
-	}
-	"Chaos_LittleChooks_Description"
-	{
-		"en"		"Spawn chickens around the map with a smaller model scale"
-	}
-	"Chaos_BigChooks_Title"
-	{
-		"en"		"Big Chooks"
-	}
-	"Chaos_BigChooks_Description"
-	{
-		"en"		"Spawns large chicken models around the map"
-	}
-	"Chaos_MamaChook_Title"
-	{
-		"en"		"Mama Chook"
-	}
-	"Chaos_MamaChook_Description"
-	{
-		"en"		"Spawn one large chicken at random location"
-	}
-	"Chaos_MoonGravity_Title"
-	{
-		"en"		"Moon Gravity"
-	}
-	"Chaos_MoonGravity_Description"
-	{
-		"en"		"Set the gravity to 300"
-	}
-	"Chaos_SlayRandomPlayer_Title"
-	{
-		"en"		"Slay Random Player On Each Team"
-	}
-	"Chaos_SlayRandomPlayer_Description"
-	{
-		"en"		"If there a 2 more or players on the team, a random player will be slain (both teams)"
-	}
-	"Chaos_TaserParty_Title"
-	{
-		"en"		"Taser Party"
-	}
-	"Chaos_TaserParty_Description"
-	{
-		"en"		"Restrict weapons to zeus/tasers. Players can boost in the direction they are shooting, tasers shoot confetti!"
-	}
-	"Chaos_InsaneGravity_Title"
-	{
-		"en"		"Insane Gravity"
-	}
-	"Chaos_InsaneGravity_Description"
-	{
-		"en"		"Set the gravity to 3000, making jumps harder"
-	}
-	"Chaos_ESP_Title"
-	{
-		"en"		"Wall Hacks"
-	}
-	"Chaos_ESP_Description"
-	{
-		"en"		"Give all players a sourcemod based ESP/Wall hacks"
-	}
-	"Chaos_RandomSlap_Title"
-	{
-		"en"		"Ghost Slaps"
-	}
-	"Chaos_RandomSlap_Description"
-	{
-		"en"		"Fling the player violently every 5-10 seconds (repeats 5 times)"
-	}
-	"Chaos_Healthshot_Title"
-	{
-		"en"		"Healthshot"
-	}
-	"Chaos_Healthshot_Description"
-	{
-		"en"		"Give players a random amount (1 - 3) of healthshots"
-	}
-	"Chaos_Jackpot_Title"
-	{
-		"en"		"Jackpot"
-	}
-	"Chaos_Jackpot_Description"
-	{
-		"en"		"Set everybodys cash money to $16000"
-	}
-	"Chaos_LightsOff_Title"
-	{
-		"en"		"Who turned the lights off?"
-	}
-	"Chaos_LightsOff_Description"
-	{
-		"en"		"Simulates low map brightness by spawning dense black fog"
-	}
-	"Chaos_QuakeFOV_Title"
-	{
-		"en"		"Quake FOV"
-	}
-	"Chaos_QuakeFOV_Description"
-	{
-		"en"		"Sets all players FOV between 110 and 160 (wide quake fov)"
-	}
-	"Chaos_Binoculars_Title"
-	{
-		"en"		"Binoculars"
-	}
-	"Chaos_Binoculars_Description"
-	{
-		"en"		"Opposite of Quake FOV, random zoomed in FOV between 20,50"
-	}
-	"Chaos_VampireHeal_Title"
-	{
-		"en"		"Vampires"
-	}
-	"Chaos_VampireHeal_Description"
-	{
-		"en"		"Players receieve the HP equal to the amount of damage done to other players (stealing their HP)"
-	}
-	"Chaos_NightVision_Title"
-	{
-		"en"		"Night Vision"
-	}
-	"Chaos_NightVision_Description"
-	{
-		"en"		"Give players item_nvgs and enable nightvision"
-	}
-	"Chaos_SmokeMap_Title"
-	{
-		"en"		"Smoke Strat"
-	}
-	"Chaos_SmokeMap_Description"
-	{
-		"en"		"Spwan Smoke particles on all locations around the map"
-	}
-	"Chaos_ReversedMovement_Title"
-	{
-		"en"		"Reversed Movement"
-	}
-	"Chaos_ReversedMovement_Description"
-	{
-		"en"		"Inverse sv_accelerate, reversing players movement"
-	}
-	"Chaos_Funky_Title"
-	{
-		"en"		"Are you feeling funky?"
-	}
-	"Chaos_Funky_Description"
-	{
-		"en"		"Enables Auto BHOP and increases sv_airaccelerate 2000"
-	}
-	"Chaos_IceySurface_Title"
-	{
-		"en"		"Icy Ground"
-	}
-	"Chaos_IceySurface_Description"
-	{
-		"en"		"Removes any ground friction, making players slide and carry momentum"
-	}
-	"Chaos_IncreasedRecoil_Title"
-	{
-		"en"		"Increased Recoil"
-	}
-	"Chaos_IncreasedRecoil_Description"
-	{
-		"en"		"Increases the recoil scale"
-	}
-	"Chaos_ReversedRecoil_Title"
-	{
-		"en"		"Reversed Recoil"
-	}
-	"Chaos_ReversedRecoil_Description"
-	{
-		"en"		"Inverses the default recoil scale"
-	}
-	"Chaos_Bumpmines_Title"
-	{
-		"en"		"Bumpmines"
-	}
-	"Chaos_Bumpmines_Description"
-	{
-		"en"		"Give all players weapon_bumpmine"
-	}
-	"Chaos_RespawnTheDead_Title"
-	{
-		"en"		"Resurrect dead players"
-	}
-	"Chaos_RespawnTheDead_Description"
-	{
-		"en"		"Respawns dead players back to spawn"
-	}
-	"Chaos_RespawnTheDead_Randomly_Title"
-	{
-		"en"		"Resurrect dead players in random locations"
-	}
-	"Chaos_RespawnTheDead_Randomly_Description"
-	{
-		"en"		"Respawns dead players and teleports them randomly on the map"
-	}
-	"Chaos_RespawnDead_LastLocation_Title"
-	{
-		"en"		"Resurrect players where they died"
-	}
-	"Chaos_RespawnDead_LastLocation_Description"
-	{
-		"en"		"Respawns dead players where they last died"
-	}
-	"Chaos_SlowSpeed_Title"
-	{
-		"en"		"0.5x movement speed"
-	}
-	"Chaos_SlowSpeed_Description"
-	{
-		"en"		"Sets players movement to half 0.5 speed"
-	}
-	"Chaos_FastSpeed_Title"
-	{
-		"en"		"3x Movement Speed"
-	}
-	"Chaos_FastSpeed_Description"
-	{
-		"en"		"Sets players movement to three 3x speed"
-	}
-	"Chaos_IgniteAllPlayers_Title"
-	{
-		"en"		"Ignite All Players"
-	}
-	"Chaos_IgniteAllPlayers_Description"
-	{
-		"en"		"Ignite all players for 10 seconds"
-	}
-	"Chaos_ChickenPlayers_Title"
-	{
-		"en"		"Make all players a chicken"
-	}
-	"Chaos_ChickenPlayers_Description"
-	{
-		"en"		"Sets all player models to a chicken"
-	}
-	"Chaos_NormalWhiteFog_Title"
-	{
-		"en"		"Fog"
-	}
-	"Chaos_NormalWhiteFog_Description"
-	{
-		"en"		"Sets the maps fog to a moderate level"
-	}
-	"Chaos_ExtremeWhiteFog_Title"
-	{
-		"en"		"Extreme Fog"
-	}
-	"Chaos_ExtremeWhiteFog_Description"
-	{
-		"en"		"Normal Fog but 100% density"
-	}
-	"Chaos_Earthquake_Title"
-	{
-		"en"		"Earthquake"
-	}
-	"Chaos_Earthquake_Description"
-	{
-		"en"		"Violently shakes all players screens"
-	}
-	"Chaos_LockPlayersAim_Title"
-	{
-		"en"		"Lock Mouse Movement"
-	}
-	"Chaos_LockPlayersAim_Description"
-	{
-		"en"		"Locks mouse movement to where they were looking"
-	}
-	"Chaos_OneBulletOneGun_Title"
-	{
-		"en"		"One Bullet One Gun"
-	}
-	"Chaos_OneBulletOneGun_Description"
-	{
-		"en"		"Replace the players weapon with a new random one every time they shoot"
-	}
-	"Chaos_DiscoFog_Title"
-	{
-		"en"		"Disco Fog"
-	}
-	"Chaos_DiscoFog_Description"
-	{
-		"en"		"Spawn fog and randomise the colour every 1 second"
-	}
-	"Chaos_Jumping_Title"
-	{
-		"en"		"Jumping"
-	}
-	"Chaos_Jumping_Description"
-	{
-		"en"		"Force players to constantly jump"
-	}
-	"Chaos_DisableForwardBack_Title"
-	{
-		"en"		"Disable W / S Keys"
-	}
-	"Chaos_DisableForwardBack_Description"
-	{
-		"en"		"Restrict players from using their W/S keys"
-	}
-	"Chaos_DisableStrafe_Title"
-	{
-		"en"		"Disable A / D Keys"
-	}
-	"Chaos_DisableStrafe_Description"
-	{
-		"en"		"Restrict players from using their A/D keys - no strafing"
-	}
-	"Chaos_ResetSpawns_Title"
-	{
-		"en"		"Teleport all players back to spawn"
-	}
-	"Chaos_ResetSpawns_Description"
-	{
-		"en"		"Teleports players back to where they first spawned that round"
-	}
-	"Chaos_SpeedShooter_Title"
-	{
-		"en"		"Speed Shooter"
-	}
-	"Chaos_SpeedShooter_Description"
-	{
-		"en"		"Increases players movement x3 whenever they shoot"
-	}
-	"Chaos_ExplosiveBullets_Title"
-	{
-		"en"		"Explosive Bullets"
-	}
-	"Chaos_ExplosiveBullets_Description"
-	{
-		"en"		"Spawns explosion particles where players shoot, causes damage around the explosion"
-	}
-	"Chaos_DiscoPlayers_Title"
-	{
-		"en"		"Random Player Colours"
-	}
-	"Chaos_DiscoPlayers_Description"
-	{
-		"en"		"Sets player models to a random colour"
-	}
-	"Chaos_SimonSays_Title"
-	{
-		"en"		"Simon Says"
-	}
-	"Chaos_SimonSays_Description"
-	{
-		"en"		"Displays a menu with a simon says command, if players fail to follow the order they take 20 damage every second"
-	}
-
-	"Chaos_RewindTenSeconds_Title"
-	{
-		"en"		"Rewind 10 Seconds"
-	}
-	"Chaos_RewindTenSeconds_Description"
-	{
-		"en"		"Teleports players back to where they were 10 seconds ago"
-	}
-	"Chaos_BuyAnywhere_Title"
-	{
-		"en"		"Buy Anywhere Enabled"
-	}
-	"Chaos_BuyAnywhere_Description"
-	{
-		"en"		"players can buy weapons anywhere on the map"
-	}
-	"Chaos_HealAllPlayers_Title"
-	{
-		"en"		"Set all players health to 100"
-	}
-	"Chaos_HealAllPlayers_Description"
-	{
-		"en"		"Sets players HP to 100"
-	}
-	"Chaos_Give100HP_Title"
-	{
-		"en"		"Give all players +100 HP"
-	}
-	"Chaos_Give100HP_Description"
-	{
-		"en"		"Gives players an additional 100 HP"
-	}
-	"Chaos_EnemyRadar_Title"
-	{
-		"en"		"Enemy Radar"
-	}
-	"Chaos_EnemyRadar_Description"
-	{
-		"en"		"Allows payers to see enemies on the radar"
-	}
-	"Chaos_Drugs_Title"
-	{
-		"en"		"Drugs"
-	}
-	"Chaos_Drugs_Description"
-	{
-		"en"		"Tilts players camera with flashing screen colours"
-	}
-	"Chaos_SpawnExplodingBarrels_Title"
-	{
-		"en"		"Exploding Barrels"
-	}
-	"Chaos_SpawnExplodingBarrels_Description"
-	{
-		"en"		"Spwans prop_exploding_barrel around the map"
-	}
-	"Chaos_SuperJump_Title"
-	{
-		"en"		"Super Jump"
-	}
-	"Chaos_SuperJump_Description"
-	{
-		"en"		"Allows players to jump higher than normal"
-	}
-	"Chaos_SpawnFlashbangs_Title"
-	{
-		"en"		"Spawn Flashbangs"
-	}
-	"Chaos_SpawnFlashbangs_Description"
-	{
-		"en"		"Spawns flashban projectiles around the map that blinds anyone looking at it"
-	}
-	"Chaos_NoCrosshair_Title"
-	{
-		"en"		"No Crosshair"
-	}
-	"Chaos_NoCrosshair_Description"
-	{
-		"en"		"Hides players crosshairs"
-	}
-	"Chaos_FakeCrash_Title"
-	{
-		"en"		"Fake Crash"
-	}
-	"Chaos_FakeCrash_Description"
-	{
-		"en"		"Causes server to timeout momentarily - sourcemod breaks the plugin as it times out, but continues as normal"
-	}
-	"Chaos_Soccerballs_Title"
-	{
-		"en"		"Soccer Balls"
-	}
-	"Chaos_Soccerballs_Description"
-	{
-		"en"		"Spawns soccerballs around the map"
-	}
-	"Chaos_FakeTeleport_Title"
-	{
-		"en"		"Fake Teleport"
-	}
-	"Chaos_FakeTeleport_Description"
-	{
-		"en"		"Teleports the players randomly around the map, but teleports them back after a few seconds"
-	}
-	"Chaos_TeleportFewMeters_Title"
-	{
-		"en"		"Teleport Players A Few Meters"
-	}
-	"Chaos_TeleportFewMeters_Description"
-	{
-		"en"		"Teleports all players to a near location around them"
-	}
-	"Chaos_Impostors_Title"
-	{
-		"en"		"Impostors"
-	}
-	"Chaos_Impostors_Description"
-	{
-		"en"		"Spawns chickens around the map and changes their model to a player"
-	}
-	"Chaos_Juggernaut_Title"
-	{
-		"en"		"Juggernauts"
-	}
-	"Chaos_Juggernaut_Description"
-	{
-		"en"		"Makes all players a juggernaut (extra HP and armour with lower speed)"
-	}
-	"Chaos_BreakTime_Title"
-	{
-		"en"		"Break Time"
-	}
-	"Chaos_BreakTime_Description"
-	{
-		"en"		"freezes players and restricts them from doing anything"
-	}
-	"Chaos_RapidFire_Title"
-	{
-		"en"		"Rapid Fire"
-	}
-	"Chaos_RapidFire_Description"
-	{
-		"en"		"Increases weapon fire rate"
-	}
-	"Chaos_DisableRadar_Title"
-	{
-		"en"		"Disable Radar"
-	}
-	"Chaos_DisableRadar_Description"
-	{
-		"en"		"Hides radar for all players"
-	}
-	"Chaos_InsaneAirSpeed_Title"
-	{
-		"en"		"Extreme Strafe Acceleration"
-	}
-	"Chaos_InsaneAirSpeed_Description"
-	{
-		"en"		"sets sv_air_max_wishspeed to 2000, has a weird strafing effect, works best with autobhop"
-	}
-	"Chaos_DropCurrentWeapon_Title"
-	{
-		"en"		"Drop Current Weapon"
-	}
-	"Chaos_DropCurrentWeapon_Description"
-	{
-		"en"		"Forces all players to drop the weapon theyre holding"
-	}
-	"Chaos_DropPrimaryWeapon_Title"
-	{
-		"en"		"Drop Primary Weapon"
-	}
-	"Chaos_DropPrimaryWeapon_Description"
-	{
-		"en"		"Forces all players to drop the weapon theyre holding"
-	}
+    {
+        "en"    "Auto Plant C4 at Bombsite B"
+    }
+    "Chaos_AutoPlantC4_Description"
+    {
+        "en"    "Auto plants the c4 bomb at the closest bombsite to the player holding the c4, if c4 is dropped, bombsite is random"
+    }
+    "Chaos_InfiniteGrenades_Title"
+    {
+        "en"    "Infinite Grenades"
+    }
+    "Chaos_InfiniteGrenades_Description"
+    {
+        "en"    "Give players grenades and set sv_infinite_ammo to 2 (nades only)"
+    }
+    "Chaos_KnifeFight_Title"
+    {
+        "en"    "Knife Fight"
+    }
+    "Chaos_KnifeFight_Description"
+    {
+        "en"    "Restricts everyones weapons to knife only"
+    }
+    "Chaos_LowRenderDistance_Title"
+    {
+        "en"    "Low Render Distance"
+    }
+    "Chaos_LowRenderDistance_Description"
+    {
+        "en"    "Set fog farz to a lower value that prevents anything further than set distance to render"
+    }
+    "Chaos_RandomWeapons_Title"
+    {
+        "en"    "Random Weapons"
+    }
+    "Chaos_RandomWeapons_Description"
+    {
+        "en"    "Give players random weapons every x seconds (interval setting). An interval of 0 will only spawn the random weapons once"
+    }
+    "Chaos_OHKO_Title"
+    {
+        "en"    "1 HP"
+    }
+    "Chaos_OHKO_Description"
+    {
+        "en"    "Sets everyones HP to 1 (One Hit Knockout)"
+    }
+    "Chaos_TeammateSwap_Title"
+    {
+        "en"    "Teammate Swap"
+    }
+    "Chaos_TeammateSwap_Description"
+    {
+        "en"    "Swap positions with all your teammates"
+    }
+    "Chaos_Flying_Title"
+    {
+        "en"    "Flying"
+    }
+    "Chaos_Flying_Description"
+    {
+        "en"    "Sets all players to noclip, but players can still be damaged"
+    }
+    "Chaos_MoneyRain_Title"
+    {
+        "en"    "Make it rain"
+    }
+    "Chaos_MoneyRain_Description"
+    {
+        "en"    "Spawns item_cash around the map that gives players $500 money"
+    }
+    "Chaos_Thirdperson_Title"
+    {
+        "en"    "Thirdperson"
+    }
+    "Chaos_Thirdperson_Description"
+    {
+        "en"    "Sets all players POV to thirdperson"
+    }
+    "Chaos_C4Chicken_Title"
+    {
+        "en"    "C4 Chicken"
+    }
+    "Chaos_C4Chicken_Description"
+    {
+        "en"    "Sets any current c4, or future planted c4 to morph into a chicken that run around the map"
+    }
+    "Chaos_AlienModelKnife_Title"
+    {
+        "en"    "Alien Knife Fight"
+    }
+    "Chaos_AlienModelKnife_Description"
+    {
+        "en"    "Sets players movement speed to 3x, restricts weapons to knife, and morphs all player models to look oddly skinny"
+    }
+    "Chaos_IsThisMexico_Title"
+    {
+        "en"    "Is This What Mexico Looks Like?"
+    }
+    "Chaos_IsThisMexico_Description"
+    {
+        "en"    "Give a thick orange hue to the map"
+    }
+    "Chaos_HeadshotOnly_Title"
+    {
+        "en"    "Headshots Only"
+    }
+    "Chaos_HeadshotOnly_Description"
+    {
+        "en"    "Sets mp_damage_headshot_only to 1, forcing players to shoot at the head only"
+    }
+    "Chaos_RandomMolotovSpawn_Title"
+    {
+        "en"    "Raining Fire"
+    }
+    "Chaos_RandomMolotovSpawn_Description"
+    {
+        "en"    "Spawns a molotov above every players head. The duration controls how many times it repeats"
+    }
+    "Chaos_RandomTeleport_Title"
+    {
+        "en"    "Random Teleport"
+    }
+    "Chaos_RandomTeleport_Description"
+    {
+        "en"    "Teleports all players to a random location"
+    }
+    "Chaos_LavaFloor_Title"
+    {
+        "en"    "THE FLOOR IS LAVA"
+    }
+    "Chaos_LavaFloor_Description"
+    {
+        "en"    "Spawns molotovs all around the map"
+    }
+    "Chaos_CrabPeople_Title"
+    {
+        "en"    "Crab People"
+    }
+    "Chaos_CrabPeople_Description"
+    {
+        "en"    "Restricts players movement to crouch walking only"
+    }
+    "Chaos_Spin180_Title"
+    {
+        "en"    "180 Spin"
+    }
+    "Chaos_Spin180_Description"
+    {
+        "en"    "Spin players cameras the opposite direction from where theyre looking"
+    }
+    "Chaos_OneWeaponOnly_Title"
+    {
+        "en"    "One weapon Only"
+    }
+    "Chaos_OneWeaponOnly_Description"
+    {
+        "en"    "Give all players the same random gun and disable weapon dropping"
+    }
+    "Chaos_NoSpread_Title"
+    {
+        "en"    "100% Weapon Accuracy"
+    }
+    "Chaos_NoSpread_Description"
+    {
+        "en"    "Set guns to have no recoil"
+    }
+    "Chaos_LittleChooks_Title"
+    {
+        "en"    "Little Chooks"
+    }
+    "Chaos_LittleChooks_Description"
+    {
+        "en"    "Spawn chickens around the map with a smaller model scale"
+    }
+    "Chaos_BigChooks_Title"
+    {
+        "en"    "Big Chooks"
+    }
+    "Chaos_BigChooks_Description"
+    {
+        "en"    "Spawns large chicken models around the map"
+    }
+    "Chaos_MamaChook_Title"
+    {
+        "en"    "Mama Chook"
+    }
+    "Chaos_MamaChook_Description"
+    {
+        "en"    "Spawn one large chicken at random location"
+    }
+    "Chaos_MoonGravity_Title"
+    {
+        "en"    "Moon Gravity"
+    }
+    "Chaos_MoonGravity_Description"
+    {
+        "en"    "Set the gravity to 300"
+    }
+    "Chaos_SlayRandomPlayer_Title"
+    {
+        "en"    "Slay Random Player On Each Team"
+    }
+    "Chaos_SlayRandomPlayer_Description"
+    {
+        "en"    "If there a 2 more or players on the team, a random player will be slain (both teams)"
+    }
+    "Chaos_TaserParty_Title"
+    {
+        "en"    "Taser Party"
+    }
+    "Chaos_TaserParty_Description"
+    {
+        "en"    "Restrict weapons to zeus/tasers. Players can boost in the direction they are shooting, tasers shoot confetti!"
+    }
+    "Chaos_InsaneGravity_Title"
+    {
+        "en"    "Insane Gravity"
+    }
+    "Chaos_InsaneGravity_Description"
+    {
+        "en"    "Set the gravity to 3000, making jumps harder"
+    }
+    "Chaos_ESP_Title"
+    {
+        "en"    "Wall Hacks"
+    }
+    "Chaos_ESP_Description"
+    {
+        "en"    "Give all players a sourcemod based ESP/Wall hacks"
+    }
+    "Chaos_RandomSlap_Title"
+    {
+        "en"    "Ghost Slaps"
+    }
+    "Chaos_RandomSlap_Description"
+    {
+        "en"    "Fling the player violently every 5-10 seconds (repeats 5 times)"
+    }
+    "Chaos_Healthshot_Title"
+    {
+        "en"    "Healthshot"
+    }
+    "Chaos_Healthshot_Description"
+    {
+        "en"    "Give players a random amount (1 - 3) of healthshots"
+    }
+    "Chaos_Jackpot_Title"
+    {
+        "en"    "Jackpot"
+    }
+    "Chaos_Jackpot_Description"
+    {
+        "en"    "Set everybodys cash money to $16000"
+    }
+    "Chaos_LightsOff_Title"
+    {
+        "en"    "Who turned the lights off?"
+    }
+    "Chaos_LightsOff_Description"
+    {
+        "en"    "Simulates low map brightness by spawning dense black fog"
+    }
+    "Chaos_QuakeFOV_Title"
+    {
+        "en"    "Quake FOV"
+    }
+    "Chaos_QuakeFOV_Description"
+    {
+        "en"    "Sets all players FOV between 110 and 160 (wide quake fov)"
+    }
+    "Chaos_Binoculars_Title"
+    {
+        "en"    "Binoculars"
+    }
+    "Chaos_Binoculars_Description"
+    {
+        "en"    "Opposite of Quake FOV, random zoomed in FOV between 20,50"
+    }
+    "Chaos_VampireHeal_Title"
+    {
+        "en"    "Vampires"
+    }
+    "Chaos_VampireHeal_Description"
+    {
+        "en"    "Players receieve the HP equal to the amount of damage done to other players (stealing their HP)"
+    }
+    "Chaos_NightVision_Title"
+    {
+        "en"    "Night Vision"
+    }
+    "Chaos_NightVision_Description"
+    {
+        "en"    "Give players item_nvgs and enable nightvision"
+    }
+    "Chaos_SmokeMap_Title"
+    {
+        "en"    "Smoke Strat"
+    }
+    "Chaos_SmokeMap_Description"
+    {
+        "en"    "Spwan Smoke particles on all locations around the map"
+    }
+    "Chaos_ReversedMovement_Title"
+    {
+        "en"    "Reversed Movement"
+    }
+    "Chaos_ReversedMovement_Description"
+    {
+        "en"    "Inverse sv_accelerate, reversing players movement"
+    }
+    "Chaos_Funky_Title"
+    {
+        "en"    "Are you feeling funky?"
+    }
+    "Chaos_Funky_Description"
+    {
+        "en"    "Enables Auto BHOP and increases sv_airaccelerate 2000"
+    }
+    "Chaos_IceySurface_Title"
+    {
+        "en"    "Icy Ground"
+    }
+    "Chaos_IceySurface_Description"
+    {
+        "en"    "Removes any ground friction, making players slide and carry momentum"
+    }
+    "Chaos_IncreasedRecoil_Title"
+    {
+        "en"    "Increased Recoil"
+    }
+    "Chaos_IncreasedRecoil_Description"
+    {
+        "en"    "Increases the recoil scale"
+    }
+    "Chaos_ReversedRecoil_Title"
+    {
+        "en"    "Reversed Recoil"
+    }
+    "Chaos_ReversedRecoil_Description"
+    {
+        "en"    "Inverses the default recoil scale"
+    }
+    "Chaos_Bumpmines_Title"
+    {
+        "en"    "Bumpmines"
+    }
+    "Chaos_Bumpmines_Description"
+    {
+        "en"    "Give all players weapon_bumpmine"
+    }
+    "Chaos_RespawnTheDead_Title"
+    {
+        "en"    "Resurrect dead players"
+    }
+    "Chaos_RespawnTheDead_Description"
+    {
+        "en"    "Respawns dead players back to spawn"
+    }
+    "Chaos_RespawnTheDead_Randomly_Title"
+    {
+        "en"    "Resurrect dead players in random locations"
+    }
+    "Chaos_RespawnTheDead_Randomly_Description"
+    {
+        "en"    "Respawns dead players and teleports them randomly on the map"
+    }
+    "Chaos_RespawnDead_LastLocation_Title"
+    {
+        "en"    "Resurrect players where they died"
+    }
+    "Chaos_RespawnDead_LastLocation_Description"
+    {
+        "en"    "Respawns dead players where they last died"
+    }
+    "Chaos_SlowSpeed_Title"
+    {
+        "en"    "0.5x movement speed"
+    }
+    "Chaos_SlowSpeed_Description"
+    {
+        "en"    "Sets players movement to half 0.5 speed"
+    }
+    "Chaos_FastSpeed_Title"
+    {
+        "en"    "3x Movement Speed"
+    }
+    "Chaos_FastSpeed_Description"
+    {
+        "en"    "Sets players movement to three 3x speed"
+    }
+    "Chaos_IgniteAllPlayers_Title"
+    {
+        "en"    "Ignite All Players"
+    }
+    "Chaos_IgniteAllPlayers_Description"
+    {
+        "en"    "Ignite all players for 10 seconds"
+    }
+    "Chaos_ChickenPlayers_Title"
+    {
+        "en"    "Make all players a chicken"
+    }
+    "Chaos_ChickenPlayers_Description"
+    {
+        "en"    "Sets all player models to a chicken"
+    }
+    "Chaos_NormalWhiteFog_Title"
+    {
+        "en"    "Fog"
+    }
+    "Chaos_NormalWhiteFog_Description"
+    {
+        "en"    "Sets the maps fog to a moderate level"
+    }
+    "Chaos_ExtremeWhiteFog_Title"
+    {
+        "en"    "Extreme Fog"
+    }
+    "Chaos_ExtremeWhiteFog_Description"
+    {
+        "en"    "Normal Fog but 100% density"
+    }
+    "Chaos_Earthquake_Title"
+    {
+        "en"    "Earthquake"
+    }
+    "Chaos_Earthquake_Description"
+    {
+        "en"    "Violently shakes all players screens"
+    }
+    "Chaos_LockPlayersAim_Title"
+    {
+        "en"    "Lock Mouse Movement"
+    }
+    "Chaos_LockPlayersAim_Description"
+    {
+        "en"    "Locks mouse movement to where they were looking"
+    }
+    "Chaos_OneBulletOneGun_Title"
+    {
+        "en"    "One Bullet One Gun"
+    }
+    "Chaos_OneBulletOneGun_Description"
+    {
+        "en"    "Replace the players weapon with a new random one every time they shoot"
+    }
+    "Chaos_DiscoFog_Title"
+    {
+        "en"    "Disco Fog"
+    }
+    "Chaos_DiscoFog_Description"
+    {
+        "en"    "Spawn fog and randomise the colour every 1 second"
+    }
+    "Chaos_Jumping_Title"
+    {
+        "en"    "Jumping"
+    }
+    "Chaos_Jumping_Description"
+    {
+        "en"    "Force players to constantly jump"
+    }
+    "Chaos_DisableForwardBack_Title"
+    {
+        "en"    "Disable W / S Keys"
+    }
+    "Chaos_DisableForwardBack_Description"
+    {
+        "en"    "Restrict players from using their W/S keys"
+    }
+    "Chaos_DisableStrafe_Title"
+    {
+        "en"    "Disable A / D Keys"
+    }
+    "Chaos_DisableStrafe_Description"
+    {
+        "en"    "Restrict players from using their A/D keys - no strafing"
+    }
+    "Chaos_ResetSpawns_Title"
+    {
+        "en"    "Teleport all players back to spawn"
+    }
+    "Chaos_ResetSpawns_Description"
+    {
+        "en"    "Teleports players back to where they first spawned that round"
+    }
+    "Chaos_SpeedShooter_Title"
+    {
+        "en"    "Speed Shooter"
+    }
+    "Chaos_SpeedShooter_Description"
+    {
+        "en"    "Increases players movement x3 whenever they shoot"
+    }
+    "Chaos_ExplosiveBullets_Title"
+    {
+        "en"    "Explosive Bullets"
+    }
+    "Chaos_ExplosiveBullets_Description"
+    {
+        "en"    "Spawns explosion particles where players shoot, causes damage around the explosion"
+    }
+    "Chaos_DiscoPlayers_Title"
+    {
+        "en"    "Random Player Colours"
+    }
+    "Chaos_DiscoPlayers_Description"
+    {
+        "en"    "Sets player models to a random colour"
+    }
+    "Chaos_SimonSays_Title"
+    {
+        "en"    "Simon Says"
+    }
+    "Chaos_SimonSays_Description"
+    {
+        "en"    "Displays a menu with a simon says command, if players fail to follow the order they take 20 damage every second"
+    }
+    "Chaos_RewindTenSeconds_Title"
+    {
+        "en"    "Rewind 10 Seconds"
+    }
+    "Chaos_RewindTenSeconds_Description"
+    {
+        "en"    "Teleports players back to where they were 10 seconds ago"
+    }
+    "Chaos_BuyAnywhere_Title"
+    {
+        "en"    "Buy Anywhere Enabled"
+    }
+    "Chaos_BuyAnywhere_Description"
+    {
+        "en"    "players can buy weapons anywhere on the map"
+    }
+    "Chaos_HealAllPlayers_Title"
+    {
+        "en"    "Set all players health to 100"
+    }
+    "Chaos_HealAllPlayers_Description"
+    {
+        "en"    "Sets players HP to 100"
+    }
+    "Chaos_Give100HP_Title"
+    {
+        "en"    "Give all players +100 HP"
+    }
+    "Chaos_Give100HP_Description"
+    {
+        "en"    "Gives players an additional 100 HP"
+    }
+    "Chaos_EnemyRadar_Title"
+    {
+        "en"    "Enemy Radar"
+    }
+    "Chaos_EnemyRadar_Description"
+    {
+        "en"    "Allows payers to see enemies on the radar"
+    }
+    "Chaos_Drugs_Title"
+    {
+        "en"    "Drugs"
+    }
+    "Chaos_Drugs_Description"
+    {
+        "en"    "Tilts players camera with flashing screen colours"
+    }
+    "Chaos_SpawnExplodingBarrels_Title"
+    {
+        "en"    "Exploding Barrels"
+    }
+    "Chaos_SpawnExplodingBarrels_Description"
+    {
+        "en"    "Spwans prop_exploding_barrel around the map"
+    }
+    "Chaos_SuperJump_Title"
+    {
+        "en"    "Super Jump"
+    }
+    "Chaos_SuperJump_Description"
+    {
+        "en"    "Allows players to jump higher than normal"
+    }
+    "Chaos_SpawnFlashbangs_Title"
+    {
+        "en"    "Spawn Flashbangs"
+    }
+    "Chaos_SpawnFlashbangs_Description"
+    {
+        "en"    "Spawns flashban projectiles around the map that blinds anyone looking at it"
+    }
+    "Chaos_NoCrosshair_Title"
+    {
+        "en"    "No Crosshair"
+    }
+    "Chaos_NoCrosshair_Description"
+    {
+        "en"    "Hides players crosshairs"
+    }
+    "Chaos_FakeCrash_Title"
+    {
+        "en"    "Fake Crash"
+    }
+    "Chaos_FakeCrash_Description"
+    {
+        "en"    "Causes server to timeout momentarily - sourcemod breaks the plugin as it times out, but continues as normal"
+    }
+    "Chaos_Soccerballs_Title"
+    {
+        "en"    "Soccer Balls"
+    }
+    "Chaos_Soccerballs_Description"
+    {
+        "en"    "Spawns soccerballs around the map"
+    }
+    "Chaos_FakeTeleport_Title"
+    {
+        "en"    "Fake Teleport"
+    }
+    "Chaos_FakeTeleport_Description"
+    {
+        "en"    "Teleports the players randomly around the map, but teleports them back after a few seconds"
+    }
+    "Chaos_TeleportFewMeters_Title"
+    {
+        "en"    "Teleport Players A Few Meters"
+    }
+    "Chaos_TeleportFewMeters_Description"
+    {
+        "en"    "Teleports all players to a near location around them"
+    }
+    "Chaos_Impostors_Title"
+    {
+        "en"    "Impostors"
+    }
+    "Chaos_Impostors_Description"
+    {
+        "en"    "Spawns chickens around the map and changes their model to a player"
+    }
+    "Chaos_Juggernaut_Title"
+    {
+        "en"    "Juggernauts"
+    }
+    "Chaos_Juggernaut_Description"
+    {
+        "en"    "Makes all players a juggernaut (extra HP and armour with lower speed)"
+    }
+    "Chaos_BreakTime_Title"
+    {
+        "en"    "Break Time"
+    }
+    "Chaos_BreakTime_Description"
+    {
+        "en"    "freezes players and restricts them from doing anything"
+    }
+    "Chaos_RapidFire_Title"
+    {
+        "en"    "Rapid Fire"
+    }
+    "Chaos_RapidFire_Description"
+    {
+        "en"    "Increases weapon fire rate"
+    }
+    "Chaos_DisableRadar_Title"
+    {
+        "en"    "Disable Radar"
+    }
+    "Chaos_DisableRadar_Description"
+    {
+        "en"    "Hides radar for all players"
+    }
+    "Chaos_InsaneAirSpeed_Title"
+    {
+        "en"    "Extreme Strafe Acceleration"
+    }
+    "Chaos_InsaneAirSpeed_Description"
+    {
+        "en"    "sets sv_air_max_wishspeed to 2000, has a weird strafing effect, works best with autobhop"
+    }
+    "Chaos_DropCurrentWeapon_Title"
+    {
+        "en"    "Drop Current Weapon"
+    }
+    "Chaos_DropCurrentWeapon_Description"
+    {
+        "en"    "Forces all players to drop the weapon theyre holding"
+    }
+    "Chaos_DropPrimaryWeapon_Title"
+    {
+        "en"    "Drop Primary Weapon"
+    }
+    "Chaos_DropPrimaryWeapon_Description"
+    {
+        "en"    "Forces all players to drop the weapon theyre holding"
+    }
+	"Chaos_Thunderstorm_Title"
+    {
+        "en"    "Thunderstorm"
+    }
+    "Chaos_Thunderstorm_Description"
+    {
+        "en"    "Spawns rain and strikes lightning around the map"
+    }
 }


### PR DESCRIPTION
Thunderstorm:
Strikes lightning around the map that damages players if struck. Spawns rain effect and changes skybox
Added Weather handler file, allows spawning of different precipitation types.

Force Reload:
Forces players to reload their currently held out weapon.
TODO: Set current ammo to 0 to ensure that they reload

Loose trigger:
Forces all players to fire their currently held weapon for 5 seconds.